### PR TITLE
Fixed broken volume in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - "28786:28786/tcp"
       - "28786:28786/udp"
     volumes:
-      - "${PWD}/server-init.cfg/.sauerbraten/server-init.cfg"
+      - "${PWD}/server-init.cfg:/.sauerbraten/server-init.cfg"


### PR DESCRIPTION
Previously, When starting the container via docker compose the config file is missing and the startup script dies. Now the volume mount is fixed so the config file is present and it starts correctly. 